### PR TITLE
Update ft.entry_type.php

### DIFF
--- a/ft.entry_type.php
+++ b/ft.entry_type.php
@@ -276,11 +276,12 @@ class Entry_type_ft extends EE_Fieldtype
 		
 		$this->field_id = $this->EE->input->get('field_id');
 		
-		$this->EE->load->library('api');
-		
-		$this->EE->api->instantiate('channel_fields');
-		
-		$this->EE->api_channel_fields = new Api_channel_fields;
+		if (!isset($this->EE->api_channel_fields)) 
+		{
+			$this->EE->load->library('api');
+			$this->EE->api->instantiate('channel_fields');
+			$this->EE->api_channel_fields = new Api_channel_fields;
+		}
 		
 		$all_fieldtypes = $this->EE->api_channel_fields->fetch_all_fieldtypes();
 		


### PR DESCRIPTION
This seems like bad news bears. You're creating a new instance of the Api_channel_fields which other add-ons may be relying on. I would either check to see if it already exists, and use it if if does, or create your own local reference and not mess with the global singleton. I believe this is what is causing conflicts with Publisher. When editing a field with Publisher installed it throws undefined property errors, e.g. "field_name" is not present.
