### PR TITLE
Remove 2nd parameter from json_encode() function

### DIFF
--- a/libraries/Entry_type.php
+++ b/libraries/Entry_type.php
@@ -95,7 +95,7 @@ class Entry_type {
         
         $this->EE->javascript->output('EntryType.setWidths('.json_encode($widths).');');
         
-        $this->EE->javascript->output('EntryType.setInvisible('.json_encode($invisible, TRUE).');');
+        $this->EE->javascript->output('EntryType.setInvisible('.json_encode($invisible).');');
     
         //show Entry Type-hidden fields when publish layouts are being edited
         //otherwise the publish layout sees the ET-hidden fields as intentionally


### PR DESCRIPTION
The options parameter was not added to json_encode() until PHP 5.3, so this is causing warnings on systems < 5.3.  Additionally, the options parameter should be a bitmask using JSON constants instead of a boolean.  http://php.net/manual/en/function.json-encode.php
