### PR TITLE
Extra CSS to hide fields like Matrix and Playa

### DIFF
--- a/libraries/Entry_type.php
+++ b/libraries/Entry_type.php
@@ -62,7 +62,7 @@ class Entry_type
             ee()->cp->add_to_head('<script type="text/javascript">'.file_get_contents(PATH_THIRD.'entry_type/javascript/EntryType.js').'</script>');
         }
 
-        ee()->cp->add_to_head('<style type="text/css">.entry-type-hidden { position: absolute !important; left: -9999px !important; }</style>');
+        ee()->cp->add_to_head('<style type="text/css">.entry-type-hidden { position: absolute !important; left: -9999px !important; visibility: hidden; display: none; }</style>');
 
         ee()->load->library('javascript');
 


### PR DESCRIPTION
Related to https://github.com/rsanchez/entry_type/issues/54

I manage a site that was recently upgraded to EE 4.3.2. We noticed that entry type was not working completely for Matrix and Playa fields. The content was hidden, but there would be an overlaid bounding box where those fields would be in the layout if they were shown.

I've added some extra styling rules to the .entry-type-hidden class to hide these boxes completely